### PR TITLE
Component support & Button Component implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To get started, simply add the crate to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-webhook = "1.0.0"
+webhook = "2.0.0"
 ```
 
 If you only want the types, you can get rid of the networking-related
@@ -39,7 +39,7 @@ dependencies by using the feature `models`.
 
 ```toml
 [dependencies]
-webhook = { version = "1.0.0", features = ["models"] }
+webhook = { version = "2.0.0", features = ["models"] }
 ```
 
 ### To do

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Discord Webhook API Wrapper
 </div>
 
 ### Example usage
+Using an application webhook, you may also create message components (so far only buttons).
 For a full example, take a look at `examples/example.rs`.
 ```rust
 let url: &str = "Webhook URL";

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,4 +1,5 @@
 use webhook::client::{WebhookClient, WebhookResult};
+use webhook::models::NonLinkButtonStyle;
 
 const IMAGE_URL: &'static str = "https://cdn.discordapp.com/avatars/312157715449249795/a_b8b3b0c35f3dee2b6586a0dd58697e29.png";
 
@@ -23,6 +24,41 @@ async fn main() -> WebhookResult<()> {
             .thumbnail(IMAGE_URL)
             .author("Lmao#0001", Some(String::from(IMAGE_URL)), Some(String::from(IMAGE_URL)))
             .field("name", "value", false))).await?;
+
+    Ok(())
+}
+
+// to try out using application webhook run:
+// `application_webhook_example(&url).await?;`
+async fn application_webhook_example(url: &str) -> WebhookResult<()> {
+    let client = WebhookClient::new(&url);
+    let webhook_info = client.get_information().await?;
+    println!("webhook: {:?}", webhook_info);
+
+    client
+        .send(|message| {
+            message
+                .username("Thoo")
+                .avatar_url(IMAGE_URL)
+                .action_row(|row| {
+                    row.regular_button(|button| {
+                        button
+                            .style(NonLinkButtonStyle::Primary)
+                            .label("Primary!")
+                            .emoji("625891304081063986", "mage", false)
+                            .custom_id("id_0")
+                    })
+                        .regular_button(|button| {
+                            button
+                                .style(NonLinkButtonStyle::Secondary)
+                                .label("Secondary!")
+                                .emoji("625891304081063986", "mage", false)
+                                .custom_id("id_1")
+                        })
+                        .link_button(|button| button.label("Click Me!").url("https://discord.com"))
+                })
+        })
+        .await?;
 
     Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,6 +38,15 @@ impl WebhookClient {
     {
         let mut message = Message::new();
         function(&mut message);
+        match message.first_error_message() {
+            None => (),
+            Some(error_message) => {
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    error_message,
+                )));
+            }
+        };
         let result = self.send_message(&message).await?;
 
         Ok(result)

--- a/src/models.rs
+++ b/src/models.rs
@@ -572,10 +572,6 @@ impl Button {
     }
 }
 
-trait ButtonConstructor {
-    fn create_button(&self) -> Option<Button>;
-}
-
 ///
 /// A data holder for shared fields of a link and regular buttons
 ///
@@ -736,6 +732,10 @@ impl RegularButton {
         self.button_base.label(label);
         self
     }
+}
+
+trait ButtonConstructor {
+    fn create_button(&self) -> Option<Button>;
 }
 
 impl ButtonConstructor for LinkButton {

--- a/src/models.rs
+++ b/src/models.rs
@@ -87,7 +87,7 @@ impl Message {
         self.context
             .borrow_mut()
             .get_error(0)
-            .and_then(|s| Some(s.to_string()))
+            .map(|s| s.to_string())
     }
 
     pub fn content(&mut self, content: &str) -> &mut Self {
@@ -126,10 +126,10 @@ impl Message {
         Func: Fn(&mut ActionRow) -> &mut ActionRow,
     {
         let mut row = ActionRow::new(&self.context);
-        if self.action_rows.len() > Self::action_row_max_len() - 1 {
+        if self.action_rows.len() > Self::max_action_row_count() - 1 {
             self.context.borrow_mut().add_error(&format!(
                 "Action row count exceeded {} (maximum)",
-                Self::action_row_max_len()
+                Self::max_action_row_count()
             ));
             return self;
         }
@@ -140,7 +140,7 @@ impl Message {
         self
     }
 
-    fn action_row_max_len() -> usize {
+    pub fn max_action_row_count() -> usize {
         5
     }
 
@@ -433,10 +433,9 @@ impl ActionRow {
     {
         let mut button = LinkButton::new(&self.context);
         func(&mut button);
-        button.create_button().and_then(|b| {
+        if let Some(b) = button.create_button() {
             self.components.push(NonCompositeComponent::Button(b));
-            Some(())
-        });
+        }
 
         self
     }
@@ -447,10 +446,9 @@ impl ActionRow {
     {
         let mut button = RegularButton::new(&self.context);
         func(&mut button);
-        button.create_button().and_then(|b| {
+        if let Some(b) = button.create_button() {
             self.components.push(NonCompositeComponent::Button(b));
-            Some(())
-        });
+        }
         self
     }
 }
@@ -565,7 +563,7 @@ impl Button {
         }
     }
 
-    fn label_max_len() -> usize {
+    pub fn label_max_len() -> usize {
         80
     }
 
@@ -746,7 +744,7 @@ impl ButtonConstructor for LinkButton {
             self.button_base
                 .context
                 .borrow_mut()
-                .add_error(&format!("Url of a Link button must be set!"));
+                .add_error("Url of a Link button must be set!");
             return None;
         }
 
@@ -766,14 +764,14 @@ impl ButtonConstructor for RegularButton {
             self.button_base
                 .context
                 .borrow_mut()
-                .add_error(&format!("Button style of a NonLink button must be set!"));
+                .add_error("Button style of a NonLink button must be set!");
             return None;
         }
         if self.custom_id.is_none() {
             self.button_base
                 .context
                 .borrow_mut()
-                .add_error(&format!("Custom ID of a NonLink button must be set!"));
+                .add_error("Custom ID of a NonLink button must be set!");
             return None;
         }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,7 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
 
 type Snowflake = String;
 
@@ -12,7 +15,45 @@ pub struct Webhook {
     pub name: Option<String>,
     pub avatar: Option<String>,
     pub token: String,
-    pub application_id: Option<Snowflake>
+    pub application_id: Option<Snowflake>,
+}
+
+#[derive(Debug)]
+struct MessageContext {
+    custom_ids: HashSet<String>,
+    errors: Vec<String>,
+}
+
+impl MessageContext {
+    /// Tries to register a custom id.
+    ///
+    /// # Arguments
+    ///
+    /// * `id`: the custom id to be registered
+    ///
+    ///
+    /// # Return value
+    /// Returns true if the custom id is unique.
+    ///
+    /// Returns false if the supplied custom id is duplicate of an already registered custom id.
+    pub fn register_custom_id(&mut self, id: &str) -> bool {
+        self.custom_ids.insert(id.to_string())
+    }
+
+    pub fn add_error(&mut self, error: &str) {
+        self.errors.push(error.to_string());
+    }
+
+    pub fn get_error(&mut self, index: usize) -> Option<&String> {
+        self.errors.get(index)
+    }
+
+    pub fn new() -> MessageContext {
+        MessageContext {
+            custom_ids: HashSet::new(),
+            errors: vec![],
+        }
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -22,11 +63,14 @@ pub struct Message {
     pub avatar_url: Option<String>,
     pub tts: bool,
     pub embeds: Vec<Embed>,
-    pub allow_mentions: Option<AllowedMentions>
+    pub allow_mentions: Option<AllowedMentions>,
+    #[serde(rename = "components")]
+    pub action_rows: Vec<ActionRow>,
+    #[serde(skip_serializing)]
+    context: Rc<RefCell<MessageContext>>,
 }
 
 impl Message {
-
     pub fn new() -> Self {
         Self {
             content: None,
@@ -34,8 +78,16 @@ impl Message {
             avatar_url: None,
             tts: false,
             embeds: vec![],
-            allow_mentions: None
+            allow_mentions: None,
+            action_rows: vec![],
+            context: Rc::new(RefCell::new(MessageContext::new())),
         }
+    }
+    pub(crate) fn first_error_message(&self) -> Option<String> {
+        self.context
+            .borrow_mut()
+            .get_error(0)
+            .and_then(|s| Some(s.to_string()))
     }
 
     pub fn content(&mut self, content: &str) -> &mut Self {
@@ -59,7 +111,9 @@ impl Message {
     }
 
     pub fn embed<Func>(&mut self, func: Func) -> &mut Self
-    where Func: Fn(&mut Embed) -> &mut Embed {
+    where
+        Func: Fn(&mut Embed) -> &mut Embed,
+    {
         let mut embed = Embed::new();
         func(&mut embed);
         self.embeds.push(embed);
@@ -67,15 +121,39 @@ impl Message {
         self
     }
 
-    pub fn allow_mentions(&mut self,
-                          parse: Option<Vec<AllowedMention>>,
-                          roles: Option<Vec<Snowflake>>,
-                          users: Option<Vec<Snowflake>>,
-                          replied_user: bool) -> &mut Self {
-        self.allow_mentions = Some(AllowedMentions::new(parse, roles, users, replied_user));
+    pub fn action_row<Func>(&mut self, func: Func) -> &mut Self
+    where
+        Func: Fn(&mut ActionRow) -> &mut ActionRow,
+    {
+        let mut row = ActionRow::new(&self.context);
+        if self.action_rows.len() > Self::action_row_max_len() - 1 {
+            self.context.borrow_mut().add_error(&format!(
+                "Action row count exceeded {} (maximum)",
+                Self::action_row_max_len()
+            ));
+            return self;
+        }
+
+        func(&mut row);
+        self.action_rows.push(row);
+
         self
     }
 
+    fn action_row_max_len() -> usize {
+        5
+    }
+
+    pub fn allow_mentions(
+        &mut self,
+        parse: Option<Vec<AllowedMention>>,
+        roles: Option<Vec<Snowflake>>,
+        users: Option<Vec<Snowflake>>,
+        replied_user: bool,
+    ) -> &mut Self {
+        self.allow_mentions = Some(AllowedMentions::new(parse, roles, users, replied_user));
+        self
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -85,7 +163,8 @@ pub struct Embed {
     embed_type: String,
     pub description: Option<String>,
     pub url: Option<String>,
-    pub timestamp: Option<String>, // ISO8601,
+    // ISO8601,
+    pub timestamp: Option<String>,
     pub color: Option<String>,
     pub footer: Option<EmbedFooter>,
     pub image: Option<EmbedImage>,
@@ -93,11 +172,10 @@ pub struct Embed {
     pub thumbnail: Option<EmbedThumbnail>,
     pub provider: Option<EmbedProvider>,
     pub author: Option<EmbedAuthor>,
-    pub fields: Vec<EmbedField>
+    pub fields: Vec<EmbedField>,
 }
 
 impl Embed {
-
     pub fn new() -> Self {
         Self {
             title: None,
@@ -112,7 +190,7 @@ impl Embed {
             thumbnail: None,
             provider: None,
             author: None,
-            fields: vec![]
+            fields: vec![],
         }
     }
 
@@ -166,27 +244,32 @@ impl Embed {
         self
     }
 
-    pub fn author(&mut self, name: &str, url: Option<String>, icon_url: Option<String>) -> &mut Self {
+    pub fn author(
+        &mut self,
+        name: &str,
+        url: Option<String>,
+        icon_url: Option<String>,
+    ) -> &mut Self {
         self.author = Some(EmbedAuthor::new(name, url, icon_url));
         self
     }
 
     pub fn field(&mut self, name: &str, value: &str, inline: bool) -> &mut Self {
         if self.fields.len() == 10 {
+            // put the error into context here instead of panic?
             panic!("You can't have more than")
         }
 
         self.fields.push(EmbedField::new(name, value, inline));
         self
     }
-
 }
 
 #[derive(Serialize, Debug)]
 pub struct EmbedField {
     pub name: String,
     pub value: String,
-    pub inline: bool
+    pub inline: bool,
 }
 
 impl EmbedField {
@@ -194,7 +277,7 @@ impl EmbedField {
         Self {
             name: name.to_owned(),
             value: value.to_owned(),
-            inline
+            inline,
         }
     }
 }
@@ -226,7 +309,7 @@ pub struct EmbedUrlSource {
 impl EmbedUrlSource {
     pub fn new(url: &str) -> Self {
         Self {
-            url: url.to_owned()
+            url: url.to_owned(),
         }
     }
 }
@@ -234,14 +317,14 @@ impl EmbedUrlSource {
 #[derive(Serialize, Debug)]
 pub struct EmbedProvider {
     pub name: String,
-    pub url: String
+    pub url: String,
 }
 
 impl EmbedProvider {
     pub fn new(name: &str, url: &str) -> Self {
         Self {
             name: name.to_owned(),
-            url: url.to_owned()
+            url: url.to_owned(),
         }
     }
 }
@@ -250,7 +333,7 @@ impl EmbedProvider {
 pub struct EmbedAuthor {
     pub name: String,
     pub url: Option<String>,
-    pub icon_url: Option<String>
+    pub icon_url: Option<String>,
 }
 
 impl EmbedAuthor {
@@ -258,7 +341,7 @@ impl EmbedAuthor {
         Self {
             name: name.to_owned(),
             url,
-            icon_url
+            icon_url,
         }
     }
 }
@@ -266,14 +349,14 @@ impl EmbedAuthor {
 pub enum AllowedMention {
     RoleMention,
     UserMention,
-    EveryoneMention
+    EveryoneMention,
 }
 
 fn resolve_allowed_mention_name(allowed_mention: AllowedMention) -> String {
     match allowed_mention {
         AllowedMention::RoleMention => "roles".to_string(),
         AllowedMention::UserMention => "users".to_string(),
-        AllowedMention::EveryoneMention => "everyone".to_string()
+        AllowedMention::EveryoneMention => "everyone".to_string(),
     }
 }
 
@@ -282,26 +365,425 @@ pub struct AllowedMentions {
     pub parse: Option<Vec<String>>,
     pub roles: Option<Vec<Snowflake>>,
     pub users: Option<Vec<Snowflake>>,
-    pub replied_user: bool
+    pub replied_user: bool,
 }
 
 impl AllowedMentions {
-    pub fn new(parse: Option<Vec<AllowedMention>>,
-               roles: Option<Vec<Snowflake>>,
-               users: Option<Vec<Snowflake>>,
-               replied_user: bool) -> Self {
+    pub fn new(
+        parse: Option<Vec<AllowedMention>>,
+        roles: Option<Vec<Snowflake>>,
+        users: Option<Vec<Snowflake>>,
+        replied_user: bool,
+    ) -> Self {
         let mut parse_strings: Vec<String> = vec![];
         if parse.is_some() {
-            parse.unwrap().into_iter().for_each(|x| {
-                parse_strings.push(resolve_allowed_mention_name(x))
-            })
+            parse
+                .unwrap()
+                .into_iter()
+                .for_each(|x| parse_strings.push(resolve_allowed_mention_name(x)))
         }
 
         Self {
             parse: Some(parse_strings),
             roles,
             users,
-            replied_user
+            replied_user,
         }
+    }
+}
+
+// ready to be extended with other components
+#[derive(Debug)]
+enum NonCompositeComponent {
+    Button(Button),
+}
+
+impl Serialize for NonCompositeComponent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            NonCompositeComponent::Button(button) => button.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct ActionRow {
+    #[serde(rename = "type")]
+    pub component_type: u8,
+    components: Vec<NonCompositeComponent>,
+    #[serde(skip_serializing)]
+    context: Rc<RefCell<MessageContext>>,
+}
+
+impl ActionRow {
+    fn new(context: &Rc<RefCell<MessageContext>>) -> ActionRow {
+        ActionRow {
+            component_type: 1,
+            components: vec![],
+            context: Rc::clone(context),
+        }
+    }
+
+    pub fn link_button<Func>(&mut self, func: Func) -> &mut Self
+    where
+        Func: Fn(&mut LinkButton) -> &mut LinkButton,
+    {
+        let mut button = LinkButton::new(&self.context);
+        func(&mut button);
+        button.create_button().and_then(|b| {
+            self.components.push(NonCompositeComponent::Button(b));
+            Some(())
+        });
+
+        self
+    }
+
+    pub fn regular_button<Func>(&mut self, func: Func) -> &mut Self
+    where
+        Func: Fn(&mut RegularButton) -> &mut RegularButton,
+    {
+        let mut button = RegularButton::new(&self.context);
+        func(&mut button);
+        button.create_button().and_then(|b| {
+            self.components.push(NonCompositeComponent::Button(b));
+            Some(())
+        });
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum NonLinkButtonStyle {
+    Primary,
+    Secondary,
+    Success,
+    Danger,
+}
+
+impl NonLinkButtonStyle {
+    fn get_button_style(&self) -> ButtonStyles {
+        match *self {
+            NonLinkButtonStyle::Primary => ButtonStyles::Primary,
+            NonLinkButtonStyle::Secondary => ButtonStyles::Secondary,
+            NonLinkButtonStyle::Success => ButtonStyles::Success,
+            NonLinkButtonStyle::Danger => ButtonStyles::Danger,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ButtonStyles {
+    Primary,
+    Secondary,
+    Success,
+    Danger,
+    Link,
+}
+
+impl ButtonStyles {
+    fn value(&self) -> i32 {
+        match *self {
+            ButtonStyles::Primary => 1,
+            ButtonStyles::Secondary => 2,
+            ButtonStyles::Success => 3,
+            ButtonStyles::Danger => 4,
+            ButtonStyles::Link => 5,
+        }
+    }
+}
+
+impl Serialize for ButtonStyles {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_i32(self.value())
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct PartialEmoji {
+    pub id: Snowflake,
+    pub name: String,
+    pub animated: Option<bool>,
+}
+
+#[derive(Serialize, Debug)]
+struct Button {
+    #[serde(rename = "type")]
+    pub component_type: i8,
+    pub style: ButtonStyles,
+    pub label: Option<String>,
+    pub emoji: Option<PartialEmoji>,
+    pub custom_id: Option<String>,
+    pub url: Option<String>,
+    pub disabled: Option<bool>,
+    #[serde(skip_serializing)]
+    context: Rc<RefCell<MessageContext>>,
+}
+
+impl Button {
+    fn new_link_button(
+        label: Option<String>,
+        emoji: Option<PartialEmoji>,
+        url: Option<String>,
+        disabled: Option<bool>,
+        context: &Rc<RefCell<MessageContext>>,
+    ) -> Self {
+        Self {
+            component_type: 2,
+            style: ButtonStyles::Link,
+            label,
+            emoji,
+            custom_id: None,
+            url,
+            disabled,
+            context: Rc::clone(context),
+        }
+    }
+
+    fn new_regular_button(
+        style: NonLinkButtonStyle,
+        label: Option<String>,
+        emoji: Option<PartialEmoji>,
+        custom_id: String,
+        disabled: Option<bool>,
+        context: &Rc<RefCell<MessageContext>>,
+    ) -> Self {
+        Self {
+            component_type: 2,
+            style: style.get_button_style(),
+            label,
+            emoji,
+            custom_id: Some(custom_id),
+            url: None,
+            disabled,
+            context: Rc::clone(context),
+        }
+    }
+
+    fn label_max_len() -> usize {
+        80
+    }
+
+    pub fn custom_id_max_len() -> usize {
+        100
+    }
+}
+
+trait ButtonConstructor {
+    fn create_button(&self) -> Option<Button>;
+}
+
+///
+/// A data holder for shared fields of a link and regular buttons
+///
+#[derive(Debug)]
+struct ButtonCommonBase {
+    pub label: Option<String>,
+    pub emoji: Option<PartialEmoji>,
+    pub disabled: Option<bool>,
+    context: Rc<RefCell<MessageContext>>,
+}
+
+impl ButtonCommonBase {
+    fn new(
+        label: Option<String>,
+        emoji: Option<PartialEmoji>,
+        disabled: Option<bool>,
+        context: &Rc<RefCell<MessageContext>>,
+    ) -> Self {
+        ButtonCommonBase {
+            label,
+            emoji,
+            disabled,
+            context: Rc::clone(context),
+        }
+    }
+    fn label(&mut self, label: &str) -> &mut Self {
+        if label.len() > Button::label_max_len() {
+            self.context.borrow_mut().add_error(&format!(
+                "Label length exceeds {} characters",
+                Button::label_max_len()
+            ));
+            return self;
+        }
+        self.label = Some(label.to_string());
+        self
+    }
+
+    fn emoji(&mut self, emoji_id: Snowflake, name: &str, animated: bool) -> &mut Self {
+        self.emoji = Some(PartialEmoji {
+            id: emoji_id,
+            name: name.to_string(),
+            animated: Some(animated),
+        });
+        self
+    }
+
+    fn disabled(&mut self, disabled: bool) -> &mut Self {
+        self.disabled = Some(disabled);
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct LinkButton {
+    button_base: ButtonCommonBase,
+    url: Option<String>,
+}
+
+impl LinkButton {
+    fn new(context: &Rc<RefCell<MessageContext>>) -> Self {
+        LinkButton {
+            button_base: ButtonCommonBase::new(None, None, None, context),
+            url: None,
+        }
+    }
+
+    pub fn url(&mut self, url: &str) -> &mut Self {
+        self.url = Some(url.to_string());
+        self
+    }
+
+    /*
+    ---------------------
+    ButtonBase delegation
+    ---------------------
+    */
+    pub fn emoji(&mut self, emoji_id: &str, name: &str, animated: bool) -> &mut Self {
+        self.button_base.emoji(emoji_id.to_string(), name, animated);
+        self
+    }
+
+    pub fn disabled(&mut self, disabled: bool) -> &mut Self {
+        self.button_base.disabled(disabled);
+        self
+    }
+
+    pub fn label(&mut self, label: &str) -> &mut Self {
+        self.button_base.label(label);
+        self
+    }
+}
+
+pub struct RegularButton {
+    button_base: ButtonCommonBase,
+    custom_id: Option<String>,
+    style: Option<NonLinkButtonStyle>,
+}
+
+impl RegularButton {
+    fn new(context: &Rc<RefCell<MessageContext>>) -> Self {
+        RegularButton {
+            button_base: ButtonCommonBase::new(None, None, None, context),
+            custom_id: None,
+            style: None,
+        }
+    }
+
+    pub fn custom_id(&mut self, custom_id: &str) -> &mut Self {
+        if custom_id.len() > Button::custom_id_max_len() {
+            self.button_base.context.borrow_mut().add_error(&format!(
+                "Custom ID length exceeds {} characters",
+                Button::custom_id_max_len()
+            ));
+            return self;
+        }
+        if !self
+            .button_base
+            .context
+            .borrow_mut()
+            .register_custom_id(custom_id)
+        {
+            self.button_base.context.borrow_mut().add_error(&format!(
+                "Attempt to use the same custom ID ({}) twice! (buttonLabel: {})",
+                custom_id,
+                match self.button_base.label.as_ref() {
+                    Some(label) => label,
+                    None => "Label not set",
+                }
+            ));
+            return self;
+        }
+
+        self.custom_id = Some(custom_id.to_string());
+        self
+    }
+
+    pub fn style(&mut self, style: NonLinkButtonStyle) -> &mut Self {
+        self.style = Some(style);
+        self
+    }
+
+    /*
+    ---------------------
+    ButtonBase delegation
+    ---------------------
+    */
+    pub fn emoji(&mut self, emoji_id: &str, name: &str, animated: bool) -> &mut Self {
+        self.button_base.emoji(emoji_id.to_string(), name, animated);
+        self
+    }
+
+    pub fn disabled(&mut self, disabled: bool) -> &mut Self {
+        self.button_base.disabled(disabled);
+        self
+    }
+
+    pub fn label(&mut self, label: &str) -> &mut Self {
+        self.button_base.label(label);
+        self
+    }
+}
+
+impl ButtonConstructor for LinkButton {
+    fn create_button(&self) -> Option<Button> {
+        if self.url.is_none() {
+            self.button_base
+                .context
+                .borrow_mut()
+                .add_error(&format!("Url of a Link button must be set!"));
+            return None;
+        }
+
+        Some(Button::new_link_button(
+            self.button_base.label.clone(),
+            self.button_base.emoji.clone(),
+            self.url.clone(),
+            self.button_base.disabled,
+            &self.button_base.context,
+        ))
+    }
+}
+
+impl ButtonConstructor for RegularButton {
+    fn create_button(&self) -> Option<Button> {
+        if self.style.is_none() {
+            self.button_base
+                .context
+                .borrow_mut()
+                .add_error(&format!("Button style of a NonLink button must be set!"));
+            return None;
+        }
+        if self.custom_id.is_none() {
+            self.button_base
+                .context
+                .borrow_mut()
+                .add_error(&format!("Custom ID of a NonLink button must be set!"));
+            return None;
+        }
+
+        Some(Button::new_regular_button(
+            self.style.as_ref().unwrap().clone(),
+            self.button_base.label.clone(),
+            self.button_base.emoji.clone(),
+            self.custom_id.as_ref().unwrap().clone(),
+            self.button_base.disabled,
+            &self.button_base.context,
+        ))
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -144,6 +144,14 @@ impl Message {
         5
     }
 
+    pub fn label_max_len() -> usize {
+        80
+    }
+
+    pub fn custom_id_max_len() -> usize {
+        100
+    }
+
     pub fn allow_mentions(
         &mut self,
         parse: Option<Vec<AllowedMention>>,
@@ -562,14 +570,6 @@ impl Button {
             context: Rc::clone(context),
         }
     }
-
-    pub fn label_max_len() -> usize {
-        80
-    }
-
-    pub fn custom_id_max_len() -> usize {
-        100
-    }
 }
 
 ///
@@ -598,10 +598,10 @@ impl ButtonCommonBase {
         }
     }
     fn label(&mut self, label: &str) -> &mut Self {
-        if label.len() > Button::label_max_len() {
+        if label.len() > Message::label_max_len() {
             self.context.borrow_mut().add_error(&format!(
                 "Label length exceeds {} characters",
-                Button::label_max_len()
+                Message::label_max_len()
             ));
             return self;
         }
@@ -680,10 +680,10 @@ impl RegularButton {
     }
 
     pub fn custom_id(&mut self, custom_id: &str) -> &mut Self {
-        if custom_id.len() > Button::custom_id_max_len() {
+        if custom_id.len() > Message::custom_id_max_len() {
             self.button_base.context.borrow_mut().add_error(&format!(
                 "Custom ID length exceeds {} characters",
-                Button::custom_id_max_len()
+                Message::custom_id_max_len()
             ));
             return self;
         }


### PR DESCRIPTION
## Changes:
* Corrected and adjusted error propagation from the client
  * basically builds from [my previous PR](https://github.com/thoo0224/webhook-rs/pull/8)
* set one code example to be ignored by `cargo test` (since it seems it was not intended to be tested anyway) 
* updated README

## Additions:
* Component support in the form of serialized enums
* Message building context to enforce the Discord API's limitations
  * e.g. the length of identifiers and labels,  number of some components
  * also added a few tests for the message context
* Fully implemented Button Components
  * added an example to `example.rs` (requires application webhook)

Pretty much all the questions I posted in [my previous PR](https://github.com/thoo0224/webhook-rs/pull/8) still hold.