### PR TITLE
Make Message struct Send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webhook"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2018"
 description = "Discord Webhook API Wrapper"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To get started, simply add the crate to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-webhook = "2.1.0"
+webhook = "2.1.1"
 ```
 
 If you only want the types, you can get rid of the networking-related
@@ -39,7 +39,7 @@ dependencies by using the feature `models`.
 
 ```toml
 [dependencies]
-webhook = { version = "2.1.0", features = ["models"] }
+webhook = { version = "2.1.1", features = ["models"] }
 ```
 
 ### To do

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use hyper_tls::HttpsConnector;
 
 use std::str::FromStr;
 
-use crate::models::{Message, Webhook};
+use crate::models::{DiscordApiCompatible, Message, MessageContext, Webhook};
 
 pub type WebhookResult<Type> = std::result::Result<Type, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -38,9 +38,10 @@ impl WebhookClient {
     {
         let mut message = Message::new();
         function(&mut message);
-        match message.first_error_message() {
-            None => (),
-            Some(error_message) => {
+        let mut message_context = MessageContext::new();
+        match message.check_compatibility(&mut message_context) {
+            Ok(_) => (),
+            Err(error_message) => {
                 return Err(Box::new(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
                     error_message,


### PR DESCRIPTION
Closes #15 (`Message` is not `Send`)

This change refactors the current internal implementation of reporting errors regarding the message incompatibility with the Discord API specification.

Rundown of changes fixing the issue:

* added `DiscordCompatible` trait which provides a way to check the compatibility of a message (and its components) using **externally provided** "context".
* removed all `context` members from component structs and adjusted the `MessageContext` struct.
* moved all message/component checks into the respective `DiscordCompatible::check_compatibility` implementations.

When making the `Message` struct `Send`, a lot of code became redundant or poorly named, thus a few more changes than the fix itself are included:

* renamed `ButtonConstructor` trait to `ToSerializableButton` (to make the trait name similar to `ToString` for example) 
* moved the concern of creating "specialized" (link, regular) serializable `Button` into this trait's implementations. (up until now this was provided by `Button::new_link/regular`).
* fixed an off-by-one error in action row message component count check

My reasoning behind versioning (`2.1.0` -> `2.1.1`) was that this is a sort of bug fix which does not change the publicly accessible API.